### PR TITLE
fix: correct default TTL from 1h to 24h on website

### DIFF
--- a/web/src/components/time-limits.tsx
+++ b/web/src/components/time-limits.tsx
@@ -20,7 +20,7 @@ export function TimeLimits() {
             </span>
           </h2>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Choose your TTL. Default is 1 hour, max is 24 hours.
+            Choose your TTL. Default is 24 hours, max is 24 hours.
             <br />
             When time's up, it's gone forever.
           </p>
@@ -41,7 +41,7 @@ export function TimeLimits() {
 
         <div className="mt-12 text-center">
           <p className="text-muted-foreground">
-            No TTL specified? Defaults to <code className="text-accent font-mono">:1h</code>
+            No TTL specified? Defaults to <code className="text-accent font-mono">:24h</code>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Fixes #176

The website's time-limits section stated the default TTL is 1 hour, but `hooks/src/controllers/HookAPI.ts` sets `defaultDuration` to `24 * 60 * 60 * 1000` (24 hours).

Updated two lines in `web/src/components/time-limits.tsx`:
- "Default is 1 hour" -> "Default is 24 hours"
- "Defaults to `:1h`" -> "Defaults to `:24h`"

The `:1h` examples in hero.tsx and how-to.tsx are intentional (showing how to explicitly set 1 hour) and left unchanged.