### PR TITLE
fix: decode the body from registry:3

### DIFF
--- a/hooks/src/server/server.ts
+++ b/hooks/src/server/server.ts
@@ -36,6 +36,7 @@ export class Server extends ServerLoader {
       type: [
         "application/json",
         "application/vnd.docker.distribution.events.v1+json",
+        "application/vnd.docker.distribution.events.v2+json",
       ],
     }));
 


### PR DESCRIPTION
Version 3 sends events with the `content-type` set to `application/vnd.docker.distribution.events.v2+json`.  The four fields that are used by this are the same, so this just supports a newer version of the server that is actually supported by upstream.

The four fields in use in `server.ts` are:
- [`body.events`](https://github.com/replicatedhq/ttl.sh/blob/main/hooks/src/controllers/HookAPI.ts#L46)
- [`event.action`](https://github.com/replicatedhq/ttl.sh/blob/main/hooks/src/controllers/HookAPI.ts#L47)
- [`event.target.repository`](https://github.com/replicatedhq/ttl.sh/blob/main/hooks/src/controllers/HookAPI.ts#L48)
- [`event.target.tag`](https://github.com/replicatedhq/ttl.sh/blob/main/hooks/src/controllers/HookAPI.ts#L49)

The last release of v2 was [v2.8.3 on Oct 2, 2023](https://github.com/distribution/distribution/releases/tag/v2.8.3).  [v3 was initially released on April 2, 2025](https://github.com/distribution/distribution/releases/tag/v3.0.0), and is seeing regular updates, including for CVEs.